### PR TITLE
Fix double deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.ref == 'refs/heads/main' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
# Description

`workflow_run` events points github.ref to main branch even when the workflow was triggered by commits to a dev branch, which causes the deployment workflow to run. This is an unexpected and undesirable behaviour. Changing the deployment condition from `github.ref == 'refs/heads/main'` to `github.event.workflow_run.head_branch == 'main'` addresses this issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
