### PR TITLE
Pass cloudfrontDistributionId to the actions context

### DIFF
--- a/.github/actions/aws-deploy/action.yml
+++ b/.github/actions/aws-deploy/action.yml
@@ -4,6 +4,9 @@ inputs:
   projectName:
     description: "The name of the project to deploy"
     required: true
+  cloudfrontDistributionId:
+    description: "The CloudFront distribution ID for cache invalidation"
+    required: true
 runs:
   using: "composite"
   steps:
@@ -65,5 +68,5 @@ runs:
 
     - name: Invalidate CloudFront cache
       if: steps.check-client-changes.outcome == 'failure'
-      run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
+      run: aws cloudfront create-invalidation --distribution-id ${{ inputs.cloudfrontDistributionId }} --paths "/*"
       shell: bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ jobs:
         uses: ./.github/actions/aws-deploy
         with:
           projectName: "aws-cdk"
+          cloudfrontDistributionId: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -39,4 +40,3 @@ jobs:
           SHORTNER_BASE_URL: ${{ secrets.SHORTNER_BASE_URL }}
           SHORTNER_TABLE_PREFIX: ${{ secrets.SHORTNER_TABLE_PREFIX }}
           REACT_APP_ENDPOINT_API: ${{ secrets.REACT_APP_ENDPOINT_API }}
-          CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}


### PR DESCRIPTION
# Description

Pass cloudfrontDistributionId to the actions context. Secrets can't be directly accessed in the actions context and needs to be passed as inputs from workflow to action.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

