### PR TITLE
Fix deployment

### DIFF
--- a/.github/actions/aws-deploy/action.yml
+++ b/.github/actions/aws-deploy/action.yml
@@ -27,9 +27,18 @@ runs:
 
     - name: Install AWS CLI
       run: |
-        curl "https://d1vvhvl2y92vvt.cloudfront.net/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-        unzip awscliv2.zip
-        sudo ./aws/install
+        if ! command -v aws &> /dev/null
+        then
+            echo "AWS CLI not found, installing..."
+            curl "https://d1vvhvl2y92vvt.cloudfront.net/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+            unzip awscliv2.zip
+            sudo ./aws/install
+        else
+            echo "AWS CLI found, updating..."
+            curl "https://d1vvhvl2y92vvt.cloudfront.net/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+            unzip awscliv2.zip
+            sudo ./aws/install --update
+        fi
       shell: bash
 
     - name: Install dependencies for client


### PR DESCRIPTION
# Description

The deployment failed as AWS prevented an overwrite of the existing AWS CLI. Update when the CLI is already present otherwise install.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

