### PR TITLE
Inject cors origin env var into lambda context

### DIFF
--- a/aws-cdk/src/infra/launcher.ts
+++ b/aws-cdk/src/infra/launcher.ts
@@ -13,6 +13,7 @@ const dataStack = new DataStack(app, "ShortnerDataStack", {
 const lambdaStack = new LambdaStack(app, "ShortnerLambdaStack", {
   shortnerTable: dataStack.shortnerTable,
   shortnerBaseUrl: getEnvVar("SHORTNER_BASE_URL"),
+  corsOrigin: getEnvVar("CORS_ORIGIN"),
 });
 new ApiStack(app, "ShortnerApiStack", {
   lambdaIntegration: lambdaStack.lambdaIntegration,

--- a/aws-cdk/src/infra/stacks/lambda-stack.ts
+++ b/aws-cdk/src/infra/stacks/lambda-stack.ts
@@ -12,6 +12,7 @@ import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
 interface LambdaStackProps extends StackProps {
   shortnerTable: ITable;
   shortnerBaseUrl: string;
+  corsOrigin: string;
 }
 export class LambdaStack extends Stack {
   public readonly lambdaIntegration: LambdaIntegration;
@@ -26,6 +27,7 @@ export class LambdaStack extends Stack {
       environment: {
         SHORTNER_TABLE_NAME: props.shortnerTable.tableName,
         SHORTENED_DOMAIN: props.shortnerBaseUrl,
+        CORS_ORIGIN: props.corsOrigin,
       },
       timeout: Duration.millis(5000),
       description:

--- a/aws-cdk/test/infra/lambda-stack.test.ts
+++ b/aws-cdk/test/infra/lambda-stack.test.ts
@@ -18,6 +18,7 @@ describe("LambdaStack", () => {
     const mockLambdaStack = new LambdaStack(testApp, "MockLambdaStack", {
       shortnerTable: MOCK_TABLE,
       shortnerBaseUrl: "short.ca/",
+      corsOrigin: "https:xhitdev.ca",
     });
 
     assert = Template.fromStack(mockLambdaStack);


### PR DESCRIPTION
# Description

Envs injected during deployment need to be explicitly defined in the definition of the Lambda Stack.